### PR TITLE
Fix dlog logging to use Swift.print

### DIFF
--- a/LayoutBuddy/AppDelegate.swift
+++ b/LayoutBuddy/AppDelegate.swift
@@ -15,7 +15,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @inline(__always)
     private func dlog(_ msg: @autoclosure () -> String) {
         #if DEBUG
-        if enableDiagnostics { dlog(msg()) }
+        if enableDiagnostics { Swift.print(msg()) }
         #endif
     }
 


### PR DESCRIPTION
## Summary
- print debug messages in `dlog` instead of recursively calling itself

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6898abac6a2c832cbaebf98d4381a076