### PR TITLE
Prevent layout switch when typing @ in email addresses

### DIFF
--- a/LayoutBuddy/AppDelegate.swift
+++ b/LayoutBuddy/AppDelegate.swift
@@ -348,6 +348,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return Unmanaged.passUnretained(event)
         }
 
+        // Keep email addresses untouched — '@' should not trigger auto-switching
+        if scalar == UnicodeScalar(64) { // '@'
+            wordBuffer = ""
+            bumpWordsAhead()
+            return Unmanaged.passUnretained(event)
+        }
+
         // Boundary → evaluate buffered word, keep boundary char
         if isBoundary(scalar) {
             processBufferedWordIfNeeded(keepFollowingBoundary: true)


### PR DESCRIPTION
## Summary
- avoid treating `@` as a word boundary that triggers layout conversion

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689b095ac96c832cbcf82642e2b85022