### PR TITLE
Handle backspace without triggering Ukrainian rewrite

### DIFF
--- a/LayoutBuddy/AppDelegate.swift
+++ b/LayoutBuddy/AppDelegate.swift
@@ -333,6 +333,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Ignore other Cmd/Ctrl shortcuts (let plain Alt combos pass)
         if hasCmd || hasCtrl { return Unmanaged.passUnretained(event) }
 
+        // Backspace/delete edits the current word buffer without triggering processing
+        if keyCode == CGKeyCode(kVK_Delete) || keyCode == CGKeyCode(kVK_ForwardDelete) {
+            if hasAlt {
+                wordBuffer = ""
+            } else if !wordBuffer.isEmpty {
+                wordBuffer.unicodeScalars.removeLast()
+            }
+            return Unmanaged.passUnretained(event)
+        }
+
         // Decode typed scalar
         var buf = [UniChar](repeating: 0, count: 4)
         var len = 0


### PR DESCRIPTION
## Summary
- Prevent backspace or forward delete from processing the buffered word, keeping layout unchanged

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689b0948dc18832c9c6657db06ee7644