### PR TITLE
Add delete key buffer handling test

### DIFF
--- a/LayoutBuddy/AppDelegate.swift
+++ b/LayoutBuddy/AppDelegate.swift
@@ -860,3 +860,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 }
+
+#if DEBUG
+extension AppDelegate {
+    /// Exposes the private `wordBuffer` for testing.
+    var testWordBuffer: String {
+        get { wordBuffer }
+        set { wordBuffer = newValue }
+    }
+
+    /// Wrapper to access the private `handleKeyEvent` in tests.
+    func testHandleKeyEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        handleKeyEvent(type: type, event: event)
+    }
+}
+#endif

--- a/LayoutBuddyTests/LayoutBuddyTests.swift
+++ b/LayoutBuddyTests/LayoutBuddyTests.swift
@@ -7,11 +7,31 @@
 
 import Testing
 @testable import LayoutBuddy
+import Carbon
+import ApplicationServices
 
 struct LayoutBuddyTests {
 
     @Test func example() async throws {
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+    @Test func testDeleteClearsBufferWithoutConversion() async throws {
+        let app = AppDelegate()
+
+        // Simulate Delete key removing last character
+        app.testWordBuffer = "word"
+        let deleteEvent = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Delete), keyDown: true)!
+        let resultDelete = app.testHandleKeyEvent(type: .keyDown, event: deleteEvent)
+        #expect(app.testWordBuffer == "wor")
+        #expect(resultDelete?.takeUnretainedValue() === deleteEvent)
+
+        // Simulate Forward Delete key removing last character
+        app.testWordBuffer = "word"
+        let forwardDeleteEvent = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_ForwardDelete), keyDown: true)!
+        let resultForward = app.testHandleKeyEvent(type: .keyDown, event: forwardDeleteEvent)
+        #expect(app.testWordBuffer == "wor")
+        #expect(resultForward?.takeUnretainedValue() === forwardDeleteEvent)
     }
 
 }


### PR DESCRIPTION
## Summary
- expose word buffer and key handler for debug testing
- verify Delete and Forward Delete keys edit word buffer without layout switch

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689cd677318c832c86f689c7d085a274