### PR TITLE
test: add uk to en apostrophe conversion test

### DIFF
--- a/LayoutBuddy/AppDelegate.swift
+++ b/LayoutBuddy/AppDelegate.swift
@@ -587,7 +587,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - EN ⇄ UK keyboard-position mapping
 
-    private func convert(_ word: String, from src: String, to dst: String) -> String {
+    func convert(_ word: String, from src: String, to dst: String) -> String {
         if src == "en", dst == "uk" { return mapWord(word, using: en2uk) }
         if src == "uk", dst == "en" { return mapWord(word, using: uk2en) }
         return word

--- a/LayoutBuddyTests/LayoutBuddyTests.swift
+++ b/LayoutBuddyTests/LayoutBuddyTests.swift
@@ -10,8 +10,11 @@ import Testing
 
 struct LayoutBuddyTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func ukrainianWordConversionProducesAsciiApostrophe() throws {
+        let delegate = AppDelegate()
+        let result = delegate.convert("п’ять", from: "uk", to: "en")
+        #expect(result == "g'znm")
+        #expect(result.contains("'"))
     }
 
 }


### PR DESCRIPTION
## Summary
- make `convert` accessible for testing
- add unit test verifying apostrophe and letter mapping for `п’ять`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689cd6fd4924832cab4d9ac51c23d0ff