### PR TITLE
Add test for '@' skipping layout switching

### DIFF
--- a/LayoutBuddy/AppDelegate.swift
+++ b/LayoutBuddy/AppDelegate.swift
@@ -859,4 +859,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
     }
+#if DEBUG
+    // MARK: - Testing helpers
+    /// Expose the internal word buffer for unit tests.
+    func test_setWordBuffer(_ text: String) { wordBuffer = text }
+    func test_getWordBuffer() -> String { wordBuffer }
+
+    /// Forward key events into the private handler for unit tests.
+    func test_handleKeyEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        handleKeyEvent(type: type, event: event)
+    }
+#endif
 }

--- a/LayoutBuddyTests/LayoutBuddyTests.swift
+++ b/LayoutBuddyTests/LayoutBuddyTests.swift
@@ -6,12 +6,32 @@
 //
 
 import Testing
+import ApplicationServices
 @testable import LayoutBuddy
 
 struct LayoutBuddyTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-    }
+    @Test func testAtSymbolSkipsLayoutSwitching() throws {
+        let app = AppDelegate()
+        app.test_setWordBuffer("hello")
 
+        guard let event = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true) else {
+            #expect(Bool(false), "Unable to create CGEvent for testing")
+            return
+        }
+
+        var at: UniChar = 64 // '@'
+        event.keyboardSetUnicodeString(stringLength: 1, unicodeString: &at)
+
+        let returned = app.test_handleKeyEvent(type: .keyDown, event: event)?.takeUnretainedValue()
+        #expect(returned === event)
+
+        // Word buffer should be cleared to avoid layout switching inside email-like strings
+        #expect(app.test_getWordBuffer().isEmpty)
+
+        var ch: UniChar = 0
+        var len: Int = 0
+        returned?.keyboardGetUnicodeString(maxStringLength: 1, actualStringLength: &len, unicodeString: &ch)
+        #expect(len == 1 && ch == at)
+    }
 }


### PR DESCRIPTION
## Summary
- expose test-only hooks in `AppDelegate` for handling key events and manipulating the word buffer
- add unit test ensuring '@' clears the word buffer without converting layout

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689cd68441e4832cb9910978a011149c