### PR TITLE
Avoid Swift keyword conflict in KeyboardLayoutManager

### DIFF
--- a/LayoutBuddy/AppCoordinator.swift
+++ b/LayoutBuddy/AppCoordinator.swift
@@ -430,7 +430,7 @@ final class AppCoordinator: NSObject {
     // Ensure layout really switched before typing
     private func ensureSwitch(to targetID: String, attempts: Int = 12, done: @escaping () -> Void) {
         func attempt(_ n: Int) {
-            self.layoutManager.switch(to: targetID)
+            self.layoutManager.switchLayout(to: targetID)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 if self.layoutManager.currentInputSourceID() == targetID || n >= attempts { done() }
                 else { attempt(n + 1) }

--- a/LayoutBuddy/KeyboardLayoutManager.swift
+++ b/LayoutBuddy/KeyboardLayoutManager.swift
@@ -51,10 +51,11 @@ final class KeyboardLayoutManager {
     func toggleLayout() {
         let current = currentInputSourceID()
         let target = (current == preferences.secondaryID) ? preferences.primaryID : preferences.secondaryID
-        switch(to: target)
+        switchLayout(to: target)
     }
 
-    func switch(to id: String) {
+    /// Switches the current keyboard layout to the specified input source ID.
+    func switchLayout(to id: String) {
         switchToInputSource(id: id)
     }
 


### PR DESCRIPTION
## Summary
- rename `switch` helper to `switchLayout` and update callers

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dca84df04832ca30752748dae5164