### PR TITLE
Buffer keystrokes during synthesis

### DIFF
--- a/LayoutBuddy/AppCoordinator.swift
+++ b/LayoutBuddy/AppCoordinator.swift
@@ -25,7 +25,11 @@ final class AppCoordinator: NSObject {
     // Global key listener
     private var eventTap: CFMachPort?
     private var runLoopSrc: CFRunLoopSource?
-    private var isSynthesizing = false
+    private var isSynthesizing = false {
+        didSet { if !isSynthesizing { flushQueuedEvents() } }
+    }
+    private var queuedEvents: [CGEvent] = []
+    private let queuedEventsLock = NSLock()
 
     // Word tracking
     private var wordBuffer = ""
@@ -133,6 +137,27 @@ final class AppCoordinator: NSObject {
         return me.handleKeyEvent(type: type, event: event)
     }
 
+    private func enqueueQueuedEvent(_ event: CGEvent) {
+        queuedEventsLock.lock()
+        queuedEvents.append(event)
+        queuedEventsLock.unlock()
+    }
+
+    private func flushQueuedEvents() {
+        queuedEventsLock.lock()
+        let events = queuedEvents
+        queuedEvents.removeAll()
+        queuedEventsLock.unlock()
+
+        for e in events {
+            e.post(tap: .cgAnnotatedSessionEventTap)
+            if let up = e.copy() {
+                up.type = .keyUp
+                up.post(tap: .cgAnnotatedSessionEventTap)
+            }
+        }
+    }
+
     // MARK: - Word parsing helpers
 
     private let letterLikePunctScalars = Set("[];',.".unicodeScalars) // ABC keys → UA letters
@@ -176,7 +201,10 @@ final class AppCoordinator: NSObject {
     // MARK: - Key handling
 
     private func handleKeyEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        if isSynthesizing { return Unmanaged.passUnretained(event) }
+        if isSynthesizing {
+            if let copy = event.copy() { enqueueQueuedEvent(copy) }
+            return nil
+        }
         guard type == .keyDown else { return Unmanaged.passUnretained(event) }
 
         let flags   = event.flags
@@ -772,6 +800,15 @@ extension AppCoordinator {
     /// Wrapper to access the private `handleKeyEvent` in tests.
     func testHandleKeyEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         handleKeyEvent(type: type, event: event)
+    }
+
+    /// Allows tests to toggle synthesizing state.
+    func testSetSynthesizing(_ value: Bool) { isSynthesizing = value }
+
+    /// Returns the number of events queued while synthesizing.
+    func testQueuedEventsCount() -> Int {
+        queuedEventsLock.lock(); defer { queuedEventsLock.unlock() }
+        return queuedEvents.count
     }
 }
 #endif

--- a/LayoutBuddy/MenuBarController.swift
+++ b/LayoutBuddy/MenuBarController.swift
@@ -11,9 +11,28 @@ final class MenuBarController: NSObject {
 
     init(layoutManager: KeyboardLayoutManager) {
         self.layoutManager = layoutManager
-        self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+
+        // Ensure status item is created on the main thread.
+        var item: NSStatusItem!
+        if Thread.isMainThread {
+            item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        } else {
+            DispatchQueue.main.sync {
+                item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+            }
+        }
+        self.statusItem = item
+
         super.init()
-        setupStatusItem()
+
+        // Setup must also occur on the main thread.
+        if Thread.isMainThread {
+            setupStatusItem()
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.setupStatusItem()
+            }
+        }
     }
 
     private func setupStatusItem() {

--- a/LayoutBuddyTests/LayoutBuddyTests.swift
+++ b/LayoutBuddyTests/LayoutBuddyTests.swift
@@ -145,4 +145,23 @@ struct LayoutBuddyTests {
         _ = app.testHandleKeyEvent(type: .keyDown, event: nEvent)
         #expect(app.testWordBuffer == "n")
     }
+
+    @Test func testBufferedEventsDuringSynthesis() throws {
+        let app = AppCoordinator()
+        app.testSetSynthesizing(true)
+
+        guard let event = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true) else {
+            #expect(Bool(false), "Unable to create CGEvent for testing")
+            return
+        }
+        var ch: UniChar = 97 // 'a'
+        event.keyboardSetUnicodeString(stringLength: 1, unicodeString: &ch)
+
+        let result = app.testHandleKeyEvent(type: .keyDown, event: event)
+        #expect(result == nil)
+        #expect(app.testQueuedEventsCount() == 1)
+
+        app.testSetSynthesizing(false)
+        #expect(app.testQueuedEventsCount() == 0)
+    }
 }


### PR DESCRIPTION
## Summary
- queue key events while synthesizing replacement words and replay them after layout switch
- add unit test to verify buffering behavior

## Testing
- `swift test 2>&1 | head -n 200` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689dd4d1ff38832c8b881637a7b83c44