### PR TITLE
Refactor event tap into controller

### DIFF
--- a/LayoutBuddy/EventTapController.swift
+++ b/LayoutBuddy/EventTapController.swift
@@ -1,0 +1,48 @@
+import Cocoa
+import ApplicationServices
+
+protocol EventTapControllerDelegate: AnyObject {
+    func handle(event: CGEvent) -> Unmanaged<CGEvent>?
+}
+
+final class EventTapController {
+    weak var delegate: EventTapControllerDelegate?
+
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+
+    func start() {
+        let mask = (1 << CGEventType.keyDown.rawValue)
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: CGEventMask(mask),
+            callback: EventTapController.callback,
+            userInfo: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        ) else { return }
+        eventTap = tap
+        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+    }
+
+    func stop() {
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+        }
+        eventTap = nil
+        runLoopSource = nil
+    }
+
+    private static let callback: CGEventTapCallBack = { _, _, event, refcon in
+        guard let refcon else { return Unmanaged.passUnretained(event) }
+        let controller = Unmanaged<EventTapController>.fromOpaque(refcon).takeUnretainedValue()
+        guard let delegate = controller.delegate else { return Unmanaged.passUnretained(event) }
+        return delegate.handle(event: event)
+    }
+}
+


### PR DESCRIPTION
## Summary
- Extract event tap setup and lifecycle into new `EventTapController`
- Update `AppCoordinator` to use `EventTapController` and implement delegate
- Simplify key event handling to operate directly on `CGEvent`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bd5a3858832ca3918fa49c053a24