### PR TITLE
Improve conversion logic: caching, defensive mapping, shared AX helpers

### DIFF
--- a/LayoutBuddy/AppCoordinator.swift
+++ b/LayoutBuddy/AppCoordinator.swift
@@ -124,6 +124,25 @@ final class AppCoordinator: NSObject {
     private let ambiguityMax = 5
     private let contextRadius = 8
 
+    // Synthetic-keystroke choreography relies on giving the target app time to
+    // commit edits and switch layouts. These are the (empirically tuned) delays;
+    // centralised here so they are documented and tunable in one place rather
+    // than sprinkled as bare literals through the async flow.
+    private enum Timing {
+        /// Let the system commit the most recent real keystroke before we edit.
+        static let commitDelay = 0.05
+        /// Poll interval while waiting for a layout switch to take effect.
+        static let layoutSettle = 0.05
+        /// Wait for ⌘C to populate the pasteboard before reading it.
+        static let clipboardCopy = 0.12
+        /// Delay before keystroke-navigation-based replacement.
+        static let navReplace = 0.1
+        /// Delay before the convert hotkey acts, so the boundary key lands first.
+        static let convertHotkey = 0.1
+        /// Re-check delay when saving a tie candidate after a boundary.
+        static let captureTie = 0.05
+    }
+
     private struct CorrectionUndo {
         let element: AXUIElement?
         let pid: pid_t
@@ -336,7 +355,7 @@ final class AppCoordinator: NSObject {
             if isRunningUnitTests || testSimulationMode {
                 work()
             } else {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: work)
+                DispatchQueue.main.asyncAfter(deadline: .now() + Timing.convertHotkey, execute: work)
             }
             return nil
         }
@@ -550,7 +569,9 @@ final class AppCoordinator: NSObject {
             let curOK = isSpelledCorrect(core, language: curSpell)
             let converted1 = convert(core, from: curLangPrefix, to: otherLangPrefix)
             dlog("[PROC] converted=\(converted1)")
-            let otherOK = !converted1.isEmpty && isSpelledCorrect(converted1, language: otherSpell)
+            // If nothing mapped, the "other language" form is identical — there
+            // is no real alternative to consider.
+            let otherOK = converted1 != core && !converted1.isEmpty && isSpelledCorrect(converted1, language: otherSpell)
 
             if curOK && otherOK {
                 captureAmbiguityLater(original: core, converted: converted1, targetLangPrefix: otherLangPrefix)
@@ -571,7 +592,8 @@ final class AppCoordinator: NSObject {
         let curOK = !suspiciousEN && isSpelledCorrect(core, language: curSpell)
         let convertedCore = convert(core, from: curLangPrefix, to: otherLangPrefix)
         dlog("[PROC] converted=\(convertedCore)")
-        let otherOK = !convertedCore.isEmpty && isSpelledCorrect(convertedCore, language: otherSpell)
+        // If nothing mapped, the "other language" form is identical — skip it.
+        let otherOK = convertedCore != core && !convertedCore.isEmpty && isSpelledCorrect(convertedCore, language: otherSpell)
 
         // Tie: both valid → save candidate, no auto-change
         if curOK && otherOK {
@@ -743,7 +765,7 @@ final class AppCoordinator: NSObject {
             let clipboardSnapshot = PasteboardSnapshot(from: pb)
             pb.clearContents()
             self.tapKeyWithFlags(CGKeyCode(kVK_ANSI_C), flags: .maskCommand)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Timing.clipboardCopy) {
                 let original = pb.string(forType: .string) ?? ""
                 clipboardSnapshot.restore(to: pb)
                 guard !original.isEmpty else { self.isSynthesizing = false; self.playSwitchSound(); return }
@@ -797,7 +819,7 @@ final class AppCoordinator: NSObject {
             self.isSynthesizing = true
 
             // Delay to let the system commit the most recent keystroke
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Timing.commitDelay) {
                 if keepFollowingBoundary { self.tapKey(.leftArrow) } // keep trailing boundary (space, etc.)
                 self.sendBackspace(times: deleteCount)
 
@@ -891,7 +913,7 @@ final class AppCoordinator: NSObject {
     private func ensureSwitch(to targetID: String, attempts: Int = 12, done: @escaping () -> Void) {
         func attempt(_ n: Int) {
             self.layoutManager.switchLayout(to: targetID)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Timing.layoutSettle) {
                 if self.layoutManager.currentInputSourceID() == targetID || n >= attempts { done() }
                 else { attempt(n + 1) }
             }
@@ -916,13 +938,33 @@ final class AppCoordinator: NSObject {
         }
     }
 
+    // A given input-source id always maps to the same script, so memoize the
+    // (otherwise string-heavy) classification. No invalidation needed: the
+    // answer for an id never changes.
+    private var ukrainianClassification: [String: Bool] = [:]
+    private var latinClassification: [String: Bool] = [:]
+
     private func isLayoutUkrainian(_ id: String) -> Bool {
+        if let cached = ukrainianClassification[id] { return cached }
+        let result = computeIsLayoutUkrainian(id)
+        ukrainianClassification[id] = result
+        return result
+    }
+
+    private func computeIsLayoutUkrainian(_ id: String) -> Bool {
         if layoutManager.isLanguage(id: id, hasPrefix: "uk") { return true }
         let name = layoutManager.inputSourceInfo(for: id)?.name.lowercased() ?? ""
         return name.contains("ukrainian") || name.contains("україн")
     }
 
     private func isLayoutLatin(_ id: String) -> Bool {
+        if let cached = latinClassification[id] { return cached }
+        let result = computeIsLayoutLatin(id)
+        latinClassification[id] = result
+        return result
+    }
+
+    private func computeIsLayoutLatin(_ id: String) -> Bool {
         let langs = layoutManager.inputSourceInfo(for: id)?.languages ?? []
         if langs.contains(where: { $0.hasPrefix("en") }) { return true }
         if langs.contains(where: { $0.localizedCaseInsensitiveContains("latn") }) { return true }
@@ -1026,6 +1068,52 @@ final class AppCoordinator: NSObject {
         AXUIElementSetAttributeValue(el, kAXValueAttribute as CFString, newValue as CFTypeRef) == .success
     }
 
+    /// Re-locates a previously captured range inside the element's *current*
+    /// text (it may have shifted as the user kept typing). Tries the stored
+    /// range first, then a context-anchored search (`before+expected+after`),
+    /// then a backwards search for the bare expected string. Returns nil if it
+    /// can no longer be found.
+    private func relocateRange(_ initial: NSRange,
+                               in ns: NSString,
+                               expecting expected: String,
+                               before: String,
+                               after: String) -> NSRange? {
+        if initial.location + initial.length <= ns.length,
+           ns.substring(with: initial) == expected {
+            return initial
+        }
+        let windowStart = max(0, initial.location - 128)
+        let windowEnd   = min(ns.length, initial.location + initial.length + 128)
+        let window = NSRange(location: windowStart, length: max(0, windowEnd - windowStart))
+
+        let needle = before + expected + after
+        var found = ns.range(of: needle, options: [], range: window)
+        if found.location != NSNotFound {
+            return NSRange(location: found.location + (before as NSString).length,
+                           length: (expected as NSString).length)
+        }
+        found = ns.range(of: expected, options: [.backwards], range: window)
+        guard found.location != NSNotFound else { return nil }
+        return found
+    }
+
+    /// Computes where the caret should land after `replacedRange` is swapped
+    /// for text of length `newLength`.
+    private func adjustedCaret(_ caret: Int,
+                               afterReplacing replacedRange: NSRange,
+                               withLength newLength: Int) -> Int {
+        let delta = newLength - replacedRange.length
+        let afterIndex = replacedRange.location + replacedRange.length
+        if caret >= afterIndex {
+            return caret + delta
+        } else if caret >= replacedRange.location && caret <= afterIndex {
+            let insideOffset = caret - replacedRange.location
+            return replacedRange.location + min(insideOffset, newLength)
+        } else {
+            return caret
+        }
+    }
+
     // If AX fails at capture time, push a "blind" candidate so hotkey can still fix it.
     private func pushBlindAmbiguity(original: String, converted: String, targetLangPrefix: String) {
         let pid = NSWorkspace.shared.frontmostApplication?.processIdentifier ?? 0
@@ -1046,7 +1134,7 @@ final class AppCoordinator: NSObject {
     private func captureAmbiguityLater(original: String,
                                        converted: String,
                                        targetLangPrefix: String,
-                                       delay: Double = 0.05) {
+                                       delay: Double = Timing.captureTie) {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
             if self.isSynthesizing {
                 self.captureAmbiguityLater(original: original,
@@ -1152,26 +1240,10 @@ final class AppCoordinator: NSObject {
 
             let ns = full as NSString
             guard let cr = cand.range else { fallbackNavigateAndReplace(cand); return }
-            var finalRange = NSRange(location: cr.location, length: cr.length)
-
-            if finalRange.location + finalRange.length > ns.length ||
-               ns.substring(with: finalRange) != cand.original {
-                // Re-locate by context near old index
-                let windowStart = max(0, Int(cr.location) - 128)
-                let windowEnd   = min(ns.length, Int(cr.location + cr.length) + 128)
-                let window = NSRange(location: windowStart, length: max(0, windowEnd - windowStart))
-                let needle = cand.before + cand.original + cand.after
-                var found = ns.range(of: needle, options: [], range: window)
-                if found.location != NSNotFound {
-                    finalRange = NSRange(location: found.location + (cand.before as NSString).length,
-                                         length: (cand.original as NSString).length)
-                } else {
-                    found = ns.range(of: cand.original, options: [.backwards], range: window)
-                    if found.location == NSNotFound {
-                        fallbackNavigateAndReplace(cand); return
-                    }
-                    finalRange = found
-                }
+            let initialRange = NSRange(location: cr.location, length: cr.length)
+            guard let finalRange = relocateRange(initialRange, in: ns, expecting: cand.original,
+                                                 before: cand.before, after: cand.after) else {
+                fallbackNavigateAndReplace(cand); return
             }
 
             // Replace via setValue on whole string (works in many fields)
@@ -1183,20 +1255,8 @@ final class AppCoordinator: NSObject {
                 isSynthesizing = true
                 let ok = axSetStringValue(el, newText)
                 // Restore caret:
-                let originalLen = finalRange.length
                 let convertedLen = (cand.converted as NSString).length
-                let delta = convertedLen - originalLen
-                let afterWordIndex = finalRange.location + finalRange.length
-
-                let newCaret: Int
-                if caretBefore.location >= afterWordIndex {
-                    newCaret = caretBefore.location + delta
-                } else if caretBefore.location >= finalRange.location && caretBefore.location <= afterWordIndex {
-                    let insideOffset = caretBefore.location - finalRange.location
-                    newCaret = finalRange.location + min(insideOffset, convertedLen)
-                } else {
-                    newCaret = caretBefore.location
-                }
+                let newCaret = adjustedCaret(caretBefore.location, afterReplacing: finalRange, withLength: convertedLen)
                 _ = axSetSelectedRange(el, NSRange(location: max(0, newCaret), length: 0))
                 isSynthesizing = false
 
@@ -1232,22 +1292,10 @@ final class AppCoordinator: NSObject {
         }
 
         let ns = full as NSString
-        var finalRange = NSRange(location: cr.location, length: cr.length)
-        if finalRange.location + finalRange.length > ns.length ||
-           ns.substring(with: finalRange) != undo.corrected {
-            let windowStart = max(0, Int(cr.location) - 128)
-            let windowEnd = min(ns.length, Int(cr.location + cr.length) + 128)
-            let window = NSRange(location: windowStart, length: max(0, windowEnd - windowStart))
-            let needle = undo.before + undo.corrected + undo.after
-            var found = ns.range(of: needle, options: [], range: window)
-            if found.location != NSNotFound {
-                finalRange = NSRange(location: found.location + (undo.before as NSString).length,
-                                     length: (undo.corrected as NSString).length)
-            } else {
-                found = ns.range(of: undo.corrected, options: [.backwards], range: window)
-                guard found.location != NSNotFound else { return false }
-                finalRange = found
-            }
+        let initialRange = NSRange(location: cr.location, length: cr.length)
+        guard let finalRange = relocateRange(initialRange, in: ns, expecting: undo.corrected,
+                                             before: undo.before, after: undo.after) else {
+            return false
         }
 
         guard axSetSelectedRange(el, finalRange) else { return false }
@@ -1258,19 +1306,7 @@ final class AppCoordinator: NSObject {
         isSynthesizing = true
         let ok = axSetStringValue(el, newText)
         let originalLen = (undo.original as NSString).length
-        let correctedLen = finalRange.length
-        let delta = originalLen - correctedLen
-        let afterWordIndex = finalRange.location + finalRange.length
-
-        let newCaret: Int
-        if caretBefore.location >= afterWordIndex {
-            newCaret = caretBefore.location + delta
-        } else if caretBefore.location >= finalRange.location && caretBefore.location <= afterWordIndex {
-            let insideOffset = caretBefore.location - finalRange.location
-            newCaret = finalRange.location + min(insideOffset, originalLen)
-        } else {
-            newCaret = caretBefore.location
-        }
+        let newCaret = adjustedCaret(caretBefore.location, afterReplacing: finalRange, withLength: originalLen)
         _ = axSetSelectedRange(el, NSRange(location: max(0, newCaret), length: 0))
         isSynthesizing = false
 
@@ -1333,7 +1369,7 @@ final class AppCoordinator: NSObject {
             return
         }
         #endif
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Timing.navReplace) {
             let curID = self.layoutManager.currentInputSourceID()
             let targetID = self.layoutID(forLanguagePrefix: cand.targetLangPrefix) ?? self.otherLayoutID()
             self.dlog("[NAVREP] start synth=\(self.isSynthesizing) curID=\(curID) targetID=\(targetID) buffer=\(self.wordParser.buffer)")

--- a/LayoutBuddy/KeyboardLayoutConverter.swift
+++ b/LayoutBuddy/KeyboardLayoutConverter.swift
@@ -1,23 +1,57 @@
 import Foundation
 
+/// Maps text typed on one keyboard layout to the characters the same physical
+/// keys would produce on another layout — used to repair text that was typed
+/// with the wrong layout active.
 enum KeyboardLayoutConverter {
+
+    /// A keyboard layout we can convert between, identified by its
+    /// spell-checker / input-source language prefix.
+    enum Script {
+        case latin      // "en"
+        case cyrillic   // "uk"
+
+        init?(languagePrefix: String) {
+            switch languagePrefix {
+            case "en": self = .latin
+            case "uk": self = .cyrillic
+            default:   return nil
+            }
+        }
+    }
+
+    /// Strongly-typed entry point. Adding a new layout pair is a matter of
+    /// extending `keyPairs` and this switch — no other call site changes.
+    static func convert(_ word: String, from source: Script, to destination: Script) -> String {
+        guard source != destination else { return word }
+        switch (source, destination) {
+        case (.latin, .cyrillic): return mapWord(word, using: latinToCyrillic)
+        case (.cyrillic, .latin): return mapWord(word, using: cyrillicToLatin)
+        default:                  return word
+        }
+    }
+
+    /// Convenience overload for call sites that thread spell-checker language
+    /// codes ("en"/"uk"). Returns the word unchanged for unsupported pairs.
     static func convert(_ word: String, from sourceLanguage: String, to destinationLanguage: String) -> String {
-        if sourceLanguage == "en", destinationLanguage == "uk" {
-            return mapWord(word, using: enToUkrainian)
-        }
-        if sourceLanguage == "uk", destinationLanguage == "en" {
-            return mapWord(word, using: ukrainianToEnglish)
-        }
-        return word
+        guard let from = Script(languagePrefix: sourceLanguage),
+              let to = Script(languagePrefix: destinationLanguage) else { return word }
+        return convert(word, from: from, to: to)
     }
 
     private static func mapWord(_ word: String, using table: [Character: String]) -> String {
         var output = ""
+        output.reserveCapacity(word.count)
         for character in word {
-            let isUppercase = character.isUppercase
-            let lowercased = Character(character.lowercased())
-            if let mapped = table[lowercased] {
-                output += isUppercase ? mapped.uppercased() : mapped
+            // `lowercased()` can produce more than one scalar; take the first
+            // grapheme defensively so arbitrary input (e.g. clipboard text)
+            // can never trap `Character.init`.
+            guard let lowered = character.lowercased().first else {
+                output.append(character)
+                continue
+            }
+            if let mapped = table[lowered] {
+                output += character.isUppercase ? mapped.uppercased() : mapped
             } else {
                 output.append(character)
             }
@@ -25,20 +59,37 @@ enum KeyboardLayoutConverter {
         return output
     }
 
-    private static let enToUkrainian: [Character: String] = [
-        "q": "й", "w": "ц", "e": "у", "r": "к", "t": "е", "y": "н", "u": "г", "i": "ш", "o": "щ", "p": "з", "[": "х", "]": "ї",
-        "a": "ф", "s": "і", "d": "в", "f": "а", "g": "п", "h": "р", "j": "о", "k": "л", "l": "д", ";": "ж", "'": "є",
-        "z": "я", "x": "ч", "c": "с", "v": "м", "b": "и", "n": "т", "m": "ь", ",": "б", ".": "ю", "/": "."
+    // MARK: - Mapping source of truth
+
+    /// Physical-key correspondence between a US (ANSI) Latin layout and the
+    /// Ukrainian (ЙЦУКЕН) layout, expressed once as `(latinKey, cyrillicKey)`
+    /// pairs. Both direction tables are derived from this list so they can
+    /// never drift out of sync.
+    ///
+    /// Note: `\` → `ґ` follows the Ukrainian-PC layout convention; on the
+    /// stock macOS "Ukrainian" layout `ґ` sits elsewhere. Adjust here if you
+    /// standardise on a different layout.
+    private static let keyPairs: [(latin: Character, cyrillic: Character)] = [
+        ("q", "й"), ("w", "ц"), ("e", "у"), ("r", "к"), ("t", "е"), ("y", "н"),
+        ("u", "г"), ("i", "ш"), ("o", "щ"), ("p", "з"), ("[", "х"), ("]", "ї"),
+        ("a", "ф"), ("s", "і"), ("d", "в"), ("f", "а"), ("g", "п"), ("h", "р"),
+        ("j", "о"), ("k", "л"), ("l", "д"), (";", "ж"), ("'", "є"),
+        ("z", "я"), ("x", "ч"), ("c", "с"), ("v", "м"), ("b", "и"), ("n", "т"),
+        ("m", "ь"), (",", "б"), (".", "ю"), ("/", "."), ("\\", "ґ"),
     ]
 
-    private static let ukrainianToEnglish: [Character: String] = {
-        var reversed: [Character: String] = [:]
-        for (key, value) in enToUkrainian {
-            for character in value {
-                reversed[character] = String(key)
-            }
-        }
-        reversed["’"] = "'"
-        return reversed
+    private static let latinToCyrillic: [Character: String] = {
+        var map: [Character: String] = [:]
+        for pair in keyPairs { map[pair.latin] = String(pair.cyrillic) }
+        return map
+    }()
+
+    private static let cyrillicToLatin: [Character: String] = {
+        var map: [Character: String] = [:]
+        for pair in keyPairs { map[pair.cyrillic] = String(pair.latin) }
+        // The typographic apostrophe that appears literally inside Ukrainian
+        // words (e.g. "п'ять") maps back to a straight quote.
+        map["’"] = "'"
+        return map
     }()
 }

--- a/LayoutBuddy/KeyboardLayoutManager.swift
+++ b/LayoutBuddy/KeyboardLayoutManager.swift
@@ -5,8 +5,44 @@ import Carbon
 final class KeyboardLayoutManager {
     private let preferences: LayoutPreferences
 
+    // The selectable-layouts list and its per-id index only change when the
+    // user enables/disables input sources, but `listSelectableKeyboardLayouts`
+    // and `inputSourceInfo(for:)` are called on the event-tap hot path (every
+    // keystroke). Cache the result and invalidate it on the relevant TIS
+    // notifications. Guarded by a lock because reads come from the event-tap
+    // thread while invalidation arrives on the notification thread.
+    private let cacheLock = NSLock()
+    private var allLayoutsCache: [InputSourceInfo]?
+    private var infoCache: [String: InputSourceInfo] = [:]
+    private var observerTokens: [NSObjectProtocol] = []
+
     init(preferences: LayoutPreferences) {
         self.preferences = preferences
+
+        let center = DistributedNotificationCenter.default()
+        let rawNames: [CFString?] = [
+            kTISNotifyEnabledKeyboardInputSourcesChanged,
+            kTISNotifySelectedKeyboardInputSourceChanged
+        ]
+        for raw in rawNames.compactMap({ $0 as String? }) {
+            let token = center.addObserver(
+                forName: Notification.Name(raw),
+                object: nil,
+                queue: nil
+            ) { [weak self] _ in self?.invalidateCaches() }
+            observerTokens.append(token)
+        }
+    }
+
+    deinit {
+        let center = DistributedNotificationCenter.default()
+        observerTokens.forEach(center.removeObserver(_:))
+    }
+
+    private func invalidateCaches() {
+        cacheLock.lock(); defer { cacheLock.unlock() }
+        allLayoutsCache = nil
+        infoCache.removeAll(keepingCapacity: true)
     }
 
     // MARK: - Input Source Info
@@ -17,6 +53,15 @@ final class KeyboardLayoutManager {
     }
 
     func listSelectableKeyboardLayouts() -> [InputSourceInfo] {
+        cacheLock.lock(); defer { cacheLock.unlock() }
+        if let cached = allLayoutsCache { return cached }
+        let infos = fetchSelectableKeyboardLayouts()
+        allLayoutsCache = infos
+        infoCache = Dictionary(infos.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        return infos
+    }
+
+    private func fetchSelectableKeyboardLayouts() -> [InputSourceInfo] {
         let query: [CFString: Any] = [
             kTISPropertyInputSourceCategory: kTISCategoryKeyboardInputSource as CFString,
             kTISPropertyInputSourceIsSelectCapable: true
@@ -35,7 +80,17 @@ final class KeyboardLayoutManager {
     }
 
     func inputSourceInfo(for id: String) -> InputSourceInfo? {
-        listSelectableKeyboardLayouts().first { $0.id == id }
+        cacheLock.lock()
+        if allLayoutsCache != nil {
+            let hit = infoCache[id]
+            cacheLock.unlock()
+            return hit
+        }
+        cacheLock.unlock()
+        // Cold cache: populate it, then read the index under the lock again.
+        _ = listSelectableKeyboardLayouts()
+        cacheLock.lock(); defer { cacheLock.unlock() }
+        return infoCache[id]
     }
 
     func isLanguage(id: String, hasPrefix prefix: String) -> Bool {

--- a/LayoutBuddyTests/LayoutBuddyTests.swift
+++ b/LayoutBuddyTests/LayoutBuddyTests.swift
@@ -28,6 +28,36 @@ final class LayoutBuddyTests: XCTestCase {
         XCTAssertEqual(app.convert("руддщ", from: "uk", to: "en"), "hello")
     }
 
+    func testConversionPreservesCase() {
+        let app = makeApp()
+
+        XCTAssertEqual(app.convert("Ghbdsn", from: "en", to: "uk"), "Привіт")
+        XCTAssertEqual(app.convert("Руддщ", from: "uk", to: "en"), "Hello")
+    }
+
+    func testConversionRoundTrips() {
+        let app = makeApp()
+
+        let typed = "ghbdsn"
+        let cyr = app.convert(typed, from: "en", to: "uk")
+        XCTAssertEqual(app.convert(cyr, from: "uk", to: "en"), typed)
+    }
+
+    func testGheWithUpturnKeyMapping() {
+        let app = makeApp()
+
+        XCTAssertEqual(app.convert("\\", from: "en", to: "uk"), "ґ")
+        XCTAssertEqual(app.convert("ґ", from: "uk", to: "en"), "\\")
+    }
+
+    func testUnmappedCharactersPassThroughUnchanged() {
+        let app = makeApp()
+
+        // Digits and unsupported language pairs leave text untouched.
+        XCTAssertEqual(app.convert("123", from: "en", to: "uk"), "123")
+        XCTAssertEqual(app.convert("hello", from: "en", to: "fr"), "hello")
+    }
+
     func testDeleteClearsBufferWithoutConversion() throws {
         let app = makeApp()
 


### PR DESCRIPTION
## What

Performance and robustness improvements to the keyboard-layout conversion path. Most of this code runs inside the `CGEventTap` callback on **every keystroke**, so cost and correctness there matter (a slow callback can get the tap disabled by macOS).

### Performance
- **Cache layout lookups** in `KeyboardLayoutManager`. The selectable-layout list and per-id index are now cached and only rebuilt when input sources change (observed via `kTISNotifyEnabledKeyboardInputSourcesChanged` / `…SelectedKeyboardInputSourceChanged`). Previously `inputSourceInfo(for:)` ran `TISCreateInputSourceList` + `compactMap` + **sort** several times per keystroke. Guarded by an `NSLock` (reads come from the event-tap thread, invalidation from the notification thread).
- **Memoize** `isLayoutLatin` / `isLayoutUkrainian` by id — a source's script never changes, so no invalidation needed.

### Robustness
- **Defensive `mapWord`**: `Character(character.lowercased())` traps when `lowercased()` yields more than one grapheme. Replaced with a safe `.first` unwrap, so arbitrary input (e.g. clipboard text fed through `forceCorrectLastWord`) can't crash.
- **No-op-conversion guard**: only treat the other-language form as valid when it actually differs from the input, avoiding false ambiguity captures.

### Maintainability
- **Single source of truth** for the mapping: both direction tables derive from one `keyPairs` list so they can't drift. Added the `\` ↔ `ґ` key (Ukrainian-PC convention, noted in a comment) and kept the typographic-apostrophe case explicit. Added a strongly-typed `Script` enum entry point (string-prefix overload kept for existing call sites).
- **Centralized timing**: scattered `asyncAfter` delay literals are now a documented `Timing` enum.
- **Extracted duplicated AX logic**: `relocateRange(…)` and `adjustedCaret(…)` replace ~50 lines of copy-pasted range-relocation and caret math shared by the ambiguity-apply and undo paths.

## Tests
- Added converter tests: case preservation, round-trip, the `ґ` key, unmapped/unsupported pass-through.
- Full suite green: **21/21** (17 existing + 4 new). Clean build, no warnings.

## Notes for reviewers
- Behavior is intended to be unchanged for the existing en↔uk flow; the changes are caching, defensiveness, and refactoring. The one intentional new mapping is `\` ↔ `ґ` — confirm the key position matches your target Ukrainian layout (stock macOS "Ukrainian" places `ґ` elsewhere than Ukrainian-PC).

## Deliberately deferred
- AX-first rework of the synthetic-keystroke timing (needs live manual verification).
- `TextTarget` protocol injection to de-interleave test scaffolding from production AX code (large refactor, deserves its own pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)